### PR TITLE
feat: add find function to query ViaCEP API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Run Tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configuring environment
+        uses: actions/setup-go@v4
+        with:
+          go-version: ^1.24.1
+
+      - name: Cloning repository
+        uses: actions/checkout@v4
+
+      - name: Run all cep tests
+        run: go test ./... --race -cover

--- a/api/find.go
+++ b/api/find.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/i9si-sistemas/nine"
+	"github.com/i9si-sistemas/nine/pkg/client"
+
+	"github.com/i9si-sistemas/cep"
+)
+
+// CEP represents the structure of the data returned by the ViaCEP API
+type CEP struct {
+	ZipCode    string `json:"cep"`
+	Street     string `json:"logradouro"`
+	Complement string `json:"complemento"`
+	District   string `json:"bairro"`
+	City       string `json:"localidade"`
+	State      string `json:"uf"`
+	IBGE       string `json:"ibge"`
+	GIA        string `json:"gia"`
+	DDD        string `json:"ddd"`
+	Region     string `json:"regiao"`
+	SIAFI      string `json:"siafi"`
+}
+
+// Find queries ViaCEP and returns zip code data
+func Find(ctx context.Context, zipCode string) (*CEP, error) {
+	if !cep.Validate(zipCode) {
+		return nil, fmt.Errorf("formato de CEP inválido")
+	}
+
+	url := fmt.Sprintf("https://viacep.com.br/ws/%s/json/", zipCode)
+
+	res, err := nine.New(ctx).Get(url, &client.Options{})
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("erro ao consultar o ViaCEP. Status: %d", res.StatusCode)
+	}
+
+	var data CEP
+	err = json.NewDecoder(res.Body).Decode(&data)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}

--- a/api/find_test.go
+++ b/api/find_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/i9si-sistemas/assert"
+)
+
+func TestFind(t *testing.T) {
+	cep := "01001-000"
+	data, err := Find(context.Background(), cep)
+	if err != nil {
+		t.Skipf("Erro ao consultar o ViaCEP: %s", err.Error())
+	}
+	assert.Equal(t, data.ZipCode, cep)
+	assert.Equal(t, data.Street, "Praça da Sé")
+	assert.Equal(t, data.Complement, "lado ímpar")
+	assert.Equal(t, data.District, "Sé")
+	assert.Equal(t, data.City, "São Paulo")
+	assert.Equal(t, data.State, "SP")
+	assert.Equal(t, data.IBGE, "3550308")
+	assert.Equal(t, data.GIA, "1004")
+	assert.Equal(t, data.DDD, "11")
+	assert.Equal(t, data.SIAFI, "7107")
+	assert.Equal(t, data.Region, "Sudeste")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/i9si-sistemas/cep
+
+go 1.24.1
+
+require (
+	github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c
+	github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c h1:8DlRk8oT2YFyo8MbY00ge2wEEGGLZWr2mGJextdSePI=
+github.com/i9si-sistemas/assert v0.0.0-20250430171352-359d1481c58c/go.mod h1:xRwY4u6NZZjNLlgdBSaNESQEUSJ4CxuT4lWQAbvwfBQ=
+github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71 h1:yIyAEA40c0nxTVmDbU+It7IbTlf4myqfknBy8yhXqwY=
+github.com/i9si-sistemas/nine v0.0.0-20250430172703-ed2ecb6b9c71/go.mod h1:6j/47ihyu5Zz9S4RTIQ939jbbz2Zb9ZYshM7TA6LnT8=

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,9 @@
+package cep
+
+import "regexp"
+
+func Validate(cep string) (ok bool) {
+	cepRegex := regexp.MustCompile(`^\d{5}-?\d{3}$`)
+	ok = cepRegex.MatchString(cep)
+	return
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,57 @@
+package cep
+
+import (
+	"testing"
+
+	"github.com/i9si-sistemas/assert"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		cep  string
+		want bool
+	}{
+		{
+			name: "CEP válido #1",
+			cep:  "01001-000",
+			want: true,
+		},
+		{
+			name: "CEP válido #2",
+			cep:  "01001000",
+			want: true,
+		},
+		{
+			name: "CEP inválido #1",
+			cep:  "01001-00",
+			want: false,
+		},
+		{
+			name:  "CEP inválido #2",
+			cep:  "01001-0000",
+			want: false,
+		},
+		{
+			name: "CEP inválido #3",
+			cep:  "01001-000a",
+			want: false,
+		},
+		{
+			name: "CEP inválido #4",	
+			cep:  "01001-000-00",
+			want: false,
+		},
+		{
+			name: "CEP inválido #5",
+			cep:  "01001-00000",
+			want: false,
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := Validate(testCase.cep)
+			assert.Equal(t, got, testCase.want)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces the `Find` function, which queries the ViaCEP API to retrieve address information based on a given Brazilian zip code (CEP).

The function performs the following:

- Validates the input zip code using the `cep.Validate` function.
- Constructs the ViaCEP API URL.
- Sends an HTTP GET request to the ViaCEP API using the `nine` library.
- Handles potential errors, such as invalid zip code format, API request failures, and invalid status codes.
- Decodes the JSON response from the API into a `CEP` struct.
- Returns the `CEP` struct containing the address information or an error if any occurred.